### PR TITLE
Add accent color and new home components

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -11,6 +11,7 @@
   --light-gray: #ddd;
   --box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   --transition: all 0.3s ease;
+  --accent-color: #f7b733;
 }
 
 * {
@@ -76,12 +77,13 @@ button {
 }
 
 .btn-primary {
-  background-color: var(--primary-color);
+  background-color: var(--accent-color);
   color: white;
 }
 
 .btn-primary:hover {
-  background-color: var(--primary-dark);
+  background-color: var(--accent-color);
+  filter: brightness(0.9);
   color: white;
 }
 
@@ -320,6 +322,54 @@ button {
   margin-bottom: 1rem;
 }
 
+/* Category Grid */
+.category-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 1.5rem;
+  margin-top: 3rem;
+}
+
+.category-card {
+  background-color: white;
+  padding: 1.5rem;
+  border-radius: 5px;
+  box-shadow: var(--box-shadow);
+  text-align: center;
+  transition: var(--transition);
+}
+
+.category-card:hover {
+  transform: translateY(-5px);
+}
+
+.category-card i {
+  font-size: 2rem;
+  color: var(--accent-color);
+  margin-bottom: 0.5rem;
+}
+
+/* Testimonials */
+.testimonials {
+  margin-top: 3rem;
+}
+
+.testimonial {
+  background-color: white;
+  padding: 1.5rem;
+  border-radius: 5px;
+  box-shadow: var(--box-shadow);
+  margin-bottom: 1.5rem;
+}
+
+.testimonial p {
+  margin-bottom: 0.5rem;
+}
+
+.testimonial .author {
+  font-weight: bold;
+}
+
 /* Dashboard */
 .dashboard-container {
   max-width: 800px;
@@ -401,6 +451,35 @@ button {
 
 .share-link button {
   border-radius: 0 4px 4px 0;
+}
+
+.copy-btn-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.copy-tooltip {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 5px);
+  background-color: var(--dark-color);
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.75rem;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.copy-tooltip.show {
+  animation: tooltip-fade 1.5s forwards;
+}
+
+@keyframes tooltip-fade {
+  0% { opacity: 0; transform: translateY(5px); }
+  20% { opacity: 1; transform: translateY(0); }
+  80% { opacity: 1; transform: translateY(0); }
+  100% { opacity: 0; transform: translateY(-5px); }
 }
 
 /* View Registry */

--- a/client/src/components/pages/CategoryGrid.js
+++ b/client/src/components/pages/CategoryGrid.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const categories = [
+  { icon: 'fas fa-plane', title: 'Travel' },
+  { icon: 'fas fa-home', title: 'Home' },
+  { icon: 'fas fa-heart', title: 'Charity' },
+  { icon: 'fas fa-child', title: 'Childcare' },
+];
+
+const CategoryGrid = () => (
+  <div className="category-grid">
+    {categories.map((cat) => (
+      <div key={cat.title} className="category-card">
+        <i className={cat.icon}></i>
+        <h4>{cat.title}</h4>
+      </div>
+    ))}
+  </div>
+);
+
+export default CategoryGrid;

--- a/client/src/components/pages/Home.js
+++ b/client/src/components/pages/Home.js
@@ -1,6 +1,8 @@
 import React, { useContext, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { AuthContext } from '../../context/auth/AuthState';
+import CategoryGrid from './CategoryGrid';
+import Testimonials from './Testimonials';
 
 const Home = () => {
   const { isAuthenticated } = useContext(AuthContext);
@@ -46,6 +48,8 @@ const Home = () => {
           <p>Contributors can securely contribute to your desired services.</p>
         </div>
       </div>
+      <CategoryGrid />
+      <Testimonials />
     </div>
   );
 };

--- a/client/src/components/pages/Testimonials.js
+++ b/client/src/components/pages/Testimonials.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const testimonials = [
+  { quote: 'Servistry made collecting funds for our honeymoon simple!', author: 'Jane & John' },
+  { quote: 'Our friends loved how easy the registry was to use.', author: 'Alex' },
+];
+
+const Testimonials = () => (
+  <div className="testimonials">
+    {testimonials.map((t, idx) => (
+      <div key={idx} className="testimonial">
+        <p>"{t.quote}"</p>
+        <p className="author">- {t.author}</p>
+      </div>
+    ))}
+  </div>
+);
+
+export default Testimonials;

--- a/client/src/components/registry/ViewRegistry.js
+++ b/client/src/components/registry/ViewRegistry.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { RegistryContext } from '../../context/registry/RegistryState';
 import { ServiceContext } from '../../context/service/ServiceState';
@@ -10,6 +10,7 @@ const ViewRegistry = () => {
   const { services, getRegistryServices, error: serviceError, clearErrors: clearServiceErrors } = useContext(ServiceContext);
   const { id } = useParams();
   const navigate = useNavigate();
+  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     getRegistry(id);
@@ -58,15 +59,19 @@ const ViewRegistry = () => {
                 value={`${window.location.origin}/registry/${registry.urlSlug}`}
                 readOnly
               />
-              <button 
-                onClick={() => {
-                  navigator.clipboard.writeText(`${window.location.origin}/registry/${registry.urlSlug}`);
-                  toast.info('Link copied to clipboard');
-                }}
-                className="btn btn-light btn-sm"
-              >
-                <i className="fas fa-copy"></i> Copy
-              </button>
+              <div className="copy-btn-wrapper">
+                <button
+                  onClick={() => {
+                    navigator.clipboard.writeText(`${window.location.origin}/registry/${registry.urlSlug}`);
+                    setCopied(true);
+                    setTimeout(() => setCopied(false), 1500);
+                  }}
+                  className="btn btn-light btn-sm"
+                >
+                  <i className="fas fa-copy"></i> Copy
+                </button>
+                <span className={`copy-tooltip${copied ? ' show' : ''}`}>Copied!</span>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- style buttons with new `--accent-color`
- create CategoryGrid and Testimonials sections
- show tooltip on registry share link
- display new sections on Home page

## Testing
- `npm test --prefix client --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861ee8ba788832381dc7d1d77d95102